### PR TITLE
fixed error that crashes homebridge if no data

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,7 @@ class AirQualityFileAccessory {
     readFile(
       this.filePath,
       (err: NodeJS.ErrnoException, data: Reading[]): void => {
-        if (err || data === null) {
+        if (err || data === null || data.length == 0) {
           this.sensor.setCharacteristic(Characteristic.StatusFault, 1)
           callback(err)
           return


### PR DESCRIPTION
if filterReadings() filters out all the data then the data object is not null but is empty. This causes the plugin and homebridge to crash. This could happen if the air quality sensor stopped writing data and the aqi.json file contained data with timestamps older than an hour.